### PR TITLE
Press F for fullscreen

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -166,6 +166,10 @@ function draw() {
 }
 
 function keyPressed() {
+  // F for fullscreen
+  if (keyCode == 70) {
+    fullscreen(!fullscreen());
+  }
   // R to reset
   if (keyCode == 82) {
     setup();


### PR DESCRIPTION
Because of security this works in a standalone page but often not when embedded in a frame, such as on editor.p5js.org